### PR TITLE
README.md: install phantomjs with homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,7 @@ The API url supports a few customisable parameters you might want to use:
 #### OS X
 
 ```bash
-brew install imagemagick gifsicle npm
-npm install phantomjs2
+brew install imagemagick gifsicle phantomjs
 ```
 
 #### Ubuntu


### PR DESCRIPTION
Homebrew doesn’t actually install just `npm`, but requires all of `node`, and is a bit of a overhead if a user doesn’t need it. If it’s only needed for `phantomjs`, then it’s much better to just install it with `brew`.