### PR TITLE
Make script work in a new way

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,18 +12,23 @@ README files on GitHub repos. This tool provides a solution for that.
 
 ### Usage
 
-Simply pass in the corresponding API url for the recording, e.g.
+```bash
+asciinema2gif [options] <asciinema_number>
+
+  options:
+    -s <size>, --size <size>      One of 'small', 'medium', 'big'
+    -t <theme>, --theme <theme>   One of 'tango', 'solarized-dark', 'solarized-light'
+    -o <file>, --output <file>    File to write to (defaults to 'asciicast.gif' in current directory)
+    -h, --help                    Show this help.
+```
+
+Example:
 
 ```bash
-$ ./asciinema2gif https://asciinema.org/api/asciicasts/8332
+$ ./asciinema2gif --size small --theme solarized-dark 8332
 ```
 
 An `asciicast.gif` file will then be generated for you to embed and share.
-
-The API url supports a few customisable parameters you might want to use:
-
-* `?size=`: `small`, `medium`, `big`
-* `?theme=`: `tango`, `solarized-dark`, `solarized-light`
 
 ### Requirements
 

--- a/asciinema2gif
+++ b/asciinema2gif
@@ -5,7 +5,7 @@
 # Halt on error.
 set -e
 
-rundir=$PWD
+readonly rundir="$(cd "$(dirname "${0}")" && pwd -P)"
 
 # Execute this in a subshell, changing to a temporary directory.
 (

--- a/asciinema2gif
+++ b/asciinema2gif
@@ -8,6 +8,28 @@ set -e
 readonly program="$(basename "${0}")"
 readonly rundir="$(cd "$(dirname "${0}")" && pwd -P)"
 
+# Check for dependencies
+depends_on() {
+  readonly local all_deps=("${@}")
+  local missing_deps=()
+
+  for dep in "${all_deps[@]}"; do
+    if ! command -v "${dep}" &>/dev/null; then
+      missing_deps+=("${dep}")
+    fi
+  done
+
+  if [[ "${#missing_deps[@]}" -gt 0 ]]; then
+    tput setaf 1
+    echo -e '\nThis script has unmet dependencies. You need to install these first:'
+    printf '  %s\n' "${missing_deps[@]}"
+    tput sgr0
+    exit 1
+  fi
+}
+
+depends_on convert gifsicle phantomjs
+
 # Show instructions when using wrong arguments
 if [[ -z "${1}" ]] || ! [[ "${1}" = 'https://asciinema.org/api/asciicasts/'* ]]; then
   echo "usage: ${program} <asciinema api url (of the form https://asciinema.org/api/asciicasts/XXXX)>"

--- a/asciinema2gif
+++ b/asciinema2gif
@@ -5,7 +5,14 @@
 # Halt on error.
 set -e
 
+readonly program="$(basename "${0}")"
 readonly rundir="$(cd "$(dirname "${0}")" && pwd -P)"
+
+# Show instructions when using wrong arguments
+if [[ -z "${1}" ]] || ! [[ "${1}" = 'https://asciinema.org/api/asciicasts/'* ]]; then
+  echo "usage: ${program} <asciinema api url (of the form https://asciinema.org/api/asciicasts/XXXX)>"
+  exit 1
+fi
 
 # Execute this in a subshell, changing to a temporary directory.
 (

--- a/asciinema2gif
+++ b/asciinema2gif
@@ -8,7 +8,7 @@ set -e
 readonly program="$(basename "${0}")"
 readonly rundir="$(cd "$(dirname "${0}")" && pwd -P)"
 
-# Check for dependencies
+# Check for dependencies.
 depends_on() {
   readonly local all_deps=("${@}")
   local missing_deps=()

--- a/asciinema2gif
+++ b/asciinema2gif
@@ -7,6 +7,8 @@ set -e
 
 readonly program="$(basename "${0}")"
 readonly rundir="$(cd "$(dirname "${0}")" && pwd -P)"
+readonly tempdir="$(mktemp -d -t asciinema2gif)"
+readonly asciinema_api='https://asciinema.org/api/asciicasts'
 
 # Check for dependencies.
 depends_on() {
@@ -30,25 +32,75 @@ depends_on() {
 
 depends_on convert gifsicle phantomjs
 
-# Show instructions when using wrong arguments
-if [[ -z "${1}" ]] || ! [[ "${1}" = 'https://asciinema.org/api/asciicasts/'* ]]; then
-  echo "usage: ${program} <asciinema api url (of the form https://asciinema.org/api/asciicasts/XXXX)>"
+# Instructions and option flags.
+function syntax_error {
+  echo "${program}: ${1}" >&2
+  echo "Try \`${program} --help\` for more information." >&2
   exit 1
+}
+
+function usage {
+  echo "
+    usage: ${program} [options] <asciinema_number>
+
+    options:
+      -s <size>, --size <size>      One of 'small', 'medium', 'big'
+      -t <theme>, --theme <theme>   One of 'tango', 'solarized-dark', 'solarized-light'
+      -o <file>, --output <file>    File to write to (defaults to 'asciicast.gif' in current directory)
+      -h, --help                    Show this help.
+  " | sed -E 's/^ {4}//'
+}
+
+while [[ "${1}" ]]; do
+  case "${1}" in
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    -s | --size)
+      asciinema_options="${asciinema_options}?size=${2}"
+      shift
+      ;;
+    -t | --theme)
+      asciinema_options="${asciinema_options}?theme=${2}"
+      shift
+      ;;
+    -o | --output)
+      output_file="${2}"
+      shift
+      ;;
+    -*)
+      syntax_error "unrecognized option: ${1}"
+      ;;
+    *)
+      break
+      ;;
+  esac
+  shift
+done
+
+# Show instructions when no arguments, more then one, or a wrong one is given.
+if [[ -z "${1}" ]] || [[ -n "${2}" ]] || ! [[ "${1}" =~ [[:digit:]]+ ]]; then
+  usage
+  exit 1
+else
+  asciinema_number="${1}"
 fi
 
-# Execute this in a subshell, changing to a temporary directory.
-(
-  readonly tempdir="$(mktemp -d -t asciinema2gif.XXX)"
-  echo "Creating and changing to temporary dir: ${tempdir}"
-  cd "${tempdir}"
+# Correct API call in case more than one option was used, and set final URL.
+asciinema_options="$(sed 's/?/\&/2' <<< "${asciinema_options}")"
+readonly asciinema_url="${asciinema_api}/${asciinema_number}${asciinema_options}"
 
-  # rm -rf frames
-  # rm -f asciicast.gif
+# Default to current output file, if not explicitly set.
+[[ -z "${output_file}" ]] && output_file="${PWD}/asciicast.gif"
 
-  phantomjs "${rundir}/render.js" "${1}"
+# Start the process.
+cd "${tempdir}"
+phantomjs "${rundir}/render.js" "${asciinema_url}"
 
-  echo '>> Generating GIF ...'
-  convert -delay 5 -loop 0 frames/*.png gif:- | gifsicle --colors=256 --delay=6 --optimize=3 > asciicast.gif
+echo '>> Generating GIF…'
+convert -delay 5 -loop 0 frames/*.png gif:- | gifsicle --colors=256 --delay=6 --optimize=3 --output='asciicast.gif'
 
-  echo ">> Generated: ${PWD}/asciicast.gif"
-)
+cd - >/dev/null
+mv "${tempdir}/asciicast.gif" "${output_file}"
+echo ">> Generated in: ${output_file}"

--- a/asciinema2gif
+++ b/asciinema2gif
@@ -9,14 +9,14 @@ readonly rundir="$(cd "$(dirname "${0}")" && pwd -P)"
 
 # Execute this in a subshell, changing to a temporary directory.
 (
-  tempdir="$(mktemp -d -t asciinema2gif.XXX)"
-  echo "Creating and changing to temporary dir: $tempdir"
-  cd "$tempdir"
+  readonly tempdir="$(mktemp -d -t asciinema2gif.XXX)"
+  echo "Creating and changing to temporary dir: ${tempdir}"
+  cd "${tempdir}"
 
   # rm -rf frames
   # rm -f asciicast.gif
 
-  phantomjs $rundir/render.js $1
+  phantomjs "${rundir}/render.js" "${1}"
 
   echo '>> Generating GIF ...'
   convert -delay 5 -loop 0 frames/*.png gif:- | gifsicle --colors=256 --delay=6 --optimize=3 > asciicast.gif


### PR DESCRIPTION
This PR expands on https://github.com/tav/asciinema2gif/pull/9 (doing it on a separate PR since it doesn’t only make fixes, but also changes). Either this one should be merged and #9 closed, or vice-versa.

This includes all the commits of #9 and adds others.

Main considerations and changes:

1. Spawning a new shell just to use a temporary directory makes little sense, especially since even if we `cd` somewhere else in the script, after it’s done will get back to the same place. Instead, just `cd` directly.
2. Leaving the gif in the temporary directory also makes little sense. It now ends by default in the current directory, but there’s a flag to let the user specify a location and name.
3. Use `--output` in `gifsicle`, instead of `>` (it’s more correct to use the tool’s flags).
4. Since the URL has to follow a specific pattern, there’s no use in requiring the user to paste it in. Simply input the cast’s number. This also saves from the mistake of inserting the URL from the website.
5. Having to pass URL parameters on the command line isn’t exactly user friendly. Worse still since you’d have to consult the web to verify what those are, in case you forget. Those options are now handled by flags in the script itself.
6. Tidied messages a bit (no point in telling a user we’re changing to a temporary directory).

In all, this should make the script more consistent with other scripts, and more straightforward to both use and understand the options.