### PR TITLE
make /api/asciicasts/ a mandatory format

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ $ asciinema2gif --theme solarized-light -o "${HOME}/Desktop/another.gif" https:/
 
 In this case an `another.gif` file will be generated on your Desktop. Using the full URL is useful if you want to get an asciicast not from the official website.
 
+#### URL Format
+
+`asciinema2gif` works by visiting the given webpage, starting the asciicast, screenshotting it repeatedly, and finally stitching it together. The `/api/asciicasts/` format of an asciinema website (e.g. https://asciinema.org/api/asciicasts/8332), as opposed to the main `/a/` format (e.g. https://asciinema.org/a/8332), makes this operation easier (see [usage](#usage)), hence why it is a requirement.
+
 ### Requirements
 
 #### OS X

--- a/asciinema2gif
+++ b/asciinema2gif
@@ -83,6 +83,10 @@ done
 if [[ -z "${1}" ]] || [[ -n "${2}" ]]; then
   usage
   exit 1
+# Show warning if a URL not containing '/api/asciicasts/' is given
+elif [[ "${1}" != *'/api/asciicasts/'* ]]; then
+  echo -e "\n$(tput setaf 1)Wrong URL format. See https://github.com/tav/asciinema2gif#url-format.$(tput sgr0)\n"
+  exit 1
 else
   # If only digits are given, use default asciinema API URL. Otherwise, use whatever is given.
   [[ "${1}" =~ ^[[:digit:]]+$ ]] && asciinema_url="${asciinema_api}/${1}" || asciinema_url="${1}"


### PR DESCRIPTION
Closes https://github.com/tav/asciinema2gif/issues/16 and should make this type of mistake a problem of the past.