### PR TITLE
asciinema2gif: fix mktemp to work on Linux

### DIFF
--- a/asciinema2gif
+++ b/asciinema2gif
@@ -7,7 +7,7 @@ set -e
 
 readonly program="$(basename "${0}")"
 readonly rundir="$(cd "$(dirname "${0}")" && pwd -P)"
-readonly tempdir="$(mktemp -d -t asciinema2gif)"
+readonly tempdir="$(mktemp -d -t asciinema2gif.XXXX)"
 readonly asciinema_api='https://asciinema.org/api/asciicasts'
 
 # Check for dependencies.


### PR DESCRIPTION
FIxes https://github.com/tav/asciinema2gif/issues/18.

Confirmed to still work on OS X, like this. If @richrd confirms this works for him as well, it can be merged.