### PR TITLE
Fix url format check

### DIFF
--- a/asciinema2gif
+++ b/asciinema2gif
@@ -89,12 +89,16 @@ if [[ -z "${1}" ]] || [[ -n "${2}" ]]; then
   usage
   exit 1
 # Show warning if a URL not containing '/api/asciicasts/' is given
-elif [[ "${1}" != *'/api/asciicasts/'* ]]; then
+elif [[ "${1}" =~ ^[[:digit:]]+$ ]]; then
+  # If only digits are given, use default asciinema API URL.
+  asciinema_url="${asciinema_api}/${1}"
+else
+  asciinema_url="${1}"
+fi
+
+if [[ $asciinema_url != *'/api/asciicasts/'* ]]; then
   echo -e "\n$(tput setaf 1)Wrong URL format. See https://github.com/tav/asciinema2gif#url-format.$(tput sgr0)\n"
   exit 1
-else
-  # If only digits are given, use default asciinema API URL. Otherwise, use whatever is given.
-  [[ "${1}" =~ ^[[:digit:]]+$ ]] && asciinema_url="${asciinema_api}/${1}" || asciinema_url="${1}"
 fi
 
 # Correct API call in case more than one option was used, and set final URL.


### PR DESCRIPTION
currently the check will fail if given just the number, the example in README will fail:

`asciinema2gif --size small --speed 2 --theme solarized-dark 8332`