### PR TITLE
asciinema2gif: improve curl command

### DIFF
--- a/asciinema2gif
+++ b/asciinema2gif
@@ -88,7 +88,7 @@ done
 if [[ -z "${1}" ]] || [[ -n "${2}" ]]; then
   usage
   exit 1
-elif [[ "${1}" =~ ^[[:alnum:]]+$ ]] && [[ $(curl -s -I "${asciinema_api}/${1}" | grep -c 200) -eq 2 ]]; then
+elif [[ "${1}" =~ ^[[:alnum:]]+$ ]] && curl --output /dev/null --silent --head --fail "${asciinema_api}/${1}"; then
   # If only digits are given, use default asciinema API URL.
   asciinema_url="${asciinema_api}/${1}"
 else


### PR DESCRIPTION
The previous command had a bit of an obscure method where it counted lines which could at some point give a wrong result. This one looks for an actual success code from the server without relying on parsing text. It also expands flags (in scripts, flags should always be their long form, for easier understanding).

You’ll notice there’s no `[[ ]]` around the command. That’s on purpose and needs to stay like that. It’s because without those we’re actually getting a return value.
