### PR TITLE
Add a Dockerfile that creates a asciinema-player container

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,11 @@ apt-get install imagemagick gifsicle npm
 npm install --global phantomjs2
 ```
 
+### Docker
+
+You can also use [docker] to render the asciicast without having to set up a web
+server yourself. More information in [docker/README.md](docker/README.md).
+
 ### Credits
 
 * [@blueyed], Daniel Hahler
@@ -78,6 +83,7 @@ Enjoy, tav <<tav@espians.com>>
 [`asciinema`]: https://asciinema.org/
 [asciinema terminal recordings]: https://asciinema.org/
 [currently possible]: https://github.com/asciinema/asciinema.org/issues/152
+[docker]: https://docker.io/
 
 [@blueyed]: https://github.com/blueyed
 [@iblech]: https://github.com/iblech

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,35 @@
+FROM nginx:stable-alpine
+
+RUN apk add --update --no-cache openssl
+
+WORKDIR /usr/share/nginx/html
+RUN set -x -e; \
+    version=2.4.0; \
+    wget \
+        https://github.com/asciinema/asciinema-player/releases/download/v$version/asciinema-player.css \
+        https://github.com/asciinema/asciinema-player/releases/download/v$version/asciinema-player.js; \
+    mkdir -p api/asciicasts asciicast;
+
+RUN echo '<html>' \
+         '<head><link rel="stylesheet" type="text/css" href="/asciinema-player.css" /></head>' \
+         '<body>' \
+         '<asciinema-player src="/asciicast/asciicast.json"></asciinema-player>' \
+         '<script src="/asciinema-player.js"></script>' \
+         '</body>' \
+         '</html>' > api/asciicasts/index.html
+
+EXPOSE 80
+
+CMD ["nginx","-g","daemon off;"]
+
+# Building the container:
+# docker build -t asciinema2gif .
+
+# Usage:
+# - Start the container:
+#   docker run -d --rm -p 3080:80 -v $PWD:/usr/share/nginx/html/asciicast --name asciinema2gif asciinema2gif
+# - Run asciinema2gif:
+#   asciinema2gif http://127.0.0.1:3080/api/asciicasts/
+# - Stop the container
+#   docker stop asciinema2gif
+

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,30 @@
+# Using docker to record movies
+
+You can use a [docker] container with [asciinema-player] as a server for
+asciinema2gif.
+
+
+## Setting up the container
+
+Requirements:
+- docker
+
+To create the container, run the following command inside this directory:
+
+    docker build -t asciinema2gif .
+
+You only have to do that once.
+
+
+## Using the container
+
+Call:
+
+    asciinema-player-container <json file> [asciinema2gif parameters]
+
+The script will start the container serving the provided recording,
+run *asciinema2gif* with the given parameters and then stop the container.
+
+
+[docker]: https://www.docker.io/
+[asciinema-player]: https://github.com/asciinema/asciinema-player

--- a/docker/asciinema-player-container
+++ b/docker/asciinema-player-container
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -e
+
+FILE=${1?Usage: $0 <jsonfile>}
+shift
+PORT=3080
+
+TMP=$(mktemp -d)
+trap 'rm -rf $TMP' EXIT
+
+cp "$FILE" "$TMP/asciicast.json"
+chmod a+rx "$TMP"
+chmod a+r "$TMP/asciicast.json"
+
+set -x
+
+docker run -i --rm -p "${PORT}:80" -v "$TMP:/usr/share/nginx/html/asciicast" --name asciinema2gif asciinema2gif &
+PID=$!
+trap 'kill -9 $PID; rm -rf $TMP' EXIT
+
+"${0%/*}/../asciinema2gif" "$@" "http://127.0.0.1:$PORT/api/asciicasts/"


### PR DESCRIPTION
I've created a Dockerfile that builds a docker container that allows the user to avoid having to install a webserver or having to upload the asciicast. Do you think this might be useful?